### PR TITLE
Encode form inputs

### DIFF
--- a/lib/openid/message.rb
+++ b/lib/openid/message.rb
@@ -288,7 +288,7 @@ module OpenID
       markup += ">\n"
 
       to_post_args.each { |k,v|
-        markup += "<input type='hidden' name='#{k}' value='#{v}' />\n"
+        markup += "<input type='hidden' name='#{k}' value='#{OpenID::Util.html_encode(v)}' />\n"
       }
       markup += "<input type='submit' value='#{submit_text}' />\n"
       markup += "\n</form>"

--- a/lib/openid/util.rb
+++ b/lib/openid/util.rb
@@ -105,6 +105,12 @@ for (var i = 0; i < elements.length; i++) {
 </html>
 "
     end
+
+    ESCAPE_TABLE = { '&' => '&amp;', '<' => '&lt;', '>' => '&gt;', '"' => '&quot;', "'" => '&#039;' }
+    # Modified from ERb's html_encode
+    def Util.html_encode(s)
+      s.to_s.gsub(/[&<>"']/) {|s| ESCAPE_TABLE[s] }
+    end
   end
 
 end

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -902,6 +902,7 @@ module OpenID
         'openid.identity' => 'http://bogus.example.invalid:port/',
         'openid.assoc_handle' => 'FLUB',
         'openid.return_to' => 'Neverland',
+        'openid.ax.value.fullname' => "Bob&Smith'"
       }
 
       @action_url = 'scheme://host:port/path?query'


### PR DESCRIPTION
I've added a Util.html_encode method that is used by Message#to_form_markup for the hidden input values. This allows values to would normally result in invalid html, such as anything with an ampersand or single quote, to be added to the OpenID messages.
