### PR TITLE
bug in ruby 1.9.2 causes crash

### DIFF
--- a/lib/openid/dh.rb
+++ b/lib/openid/dh.rb
@@ -57,7 +57,7 @@ module OpenID
       end
 
       if String.method_defined? :bytes
-        s.bytes.zip(t.bytes).map{|sb,tb| sb^tb}.pack('C*')
+        s.bytes.to_a.zip(t.bytes.to_a).map{|sb,tb| sb^tb}.pack('C*')
       else
         indices = 0...(s.length)
         chrs = indices.collect {|i| (s[i]^t[i]).chr}


### PR DESCRIPTION
bug in 1.9.2 interpreter causes crash when using 'zip' on enumerables of bytes, this is a work around until ruby is fixed.
