### PR TITLE
Fix cleanup AR associations whose expiry is past, not upcoming

### DIFF
--- a/examples/active_record_openid_store/lib/openid_ar_store.rb
+++ b/examples/active_record_openid_store/lib/openid_ar_store.rb
@@ -51,7 +51,7 @@ class ActiveRecordStore < OpenID::Store::Interface
 
   def cleanup_associations
     now = Time.now.to_i
-    Association.delete_all(['issued + lifetime > ?',now])
+    Association.delete_all(['issued + lifetime < ?',now])
   end
 
 end


### PR DESCRIPTION
It seems the sense of the comparison was accidentally inverted.
