### PR TITLE
Adding support for AX aliases and removing count when not needed

### DIFF
--- a/lib/openid/extensions/ax.rb
+++ b/lib/openid/extensions/ax.rb
@@ -434,6 +434,7 @@ module OpenID
             if values.empty? # @data defaults to []
               zero_value_types << attr_info
             end
+
             if attr_info.count != UNLIMITED_VALUES and attr_info.count < values.size
               raise Error, "More than the number of requested values were specified for #{attr_info.type_uri.inspect}"
             end

--- a/test/test_ax.rb
+++ b/test/test_ax.rb
@@ -486,6 +486,7 @@ module OpenID
       def setup
         @msg = FetchResponse.new
         @value_a = 'commodity'
+        @value_a1 = 'value2'
         @type_a = 'http://blood.transfusion/'
         @name_a = 'george'
         @request_update_url = 'http://some.url.that.is.awesome/'
@@ -538,16 +539,36 @@ module OpenID
         assert_equal(eargs, @msg.get_extension_args(req))
       end
 
-      def test_get_extension_args_some_request
+      def test_get_extension_args_single_value_response
+        # Single values do NOT have a count, and 
+        # do not use the array extension
         eargs = {
           'mode' => 'fetch_response',
           'type.' + @name_a => @type_a,
-          'value.' + @name_a + '.1' => @value_a,
-          'count.' + @name_a =>  '1'
+          'value.' + @name_a  => @value_a
         }
         req = FetchRequest.new
         req.add(AttrInfo.new(@type_a, @name_a))
         @msg.add_value(@type_a, @value_a)
+        assert_equal(eargs, @msg.get_extension_args(req))
+      end
+
+      def test_get_extension_args_array_value_response
+        # Multiple array values add the count, and array index
+        # to each value
+        eargs = {
+          'mode' => 'fetch_response',
+          'type.' + @name_a => @type_a,
+          'value.' + @name_a + ".1" => @value_a,
+          'value.' + @name_a + ".2" => @value_a1,
+          'count.' + @name_a => '2'
+        }
+        req = FetchRequest.new
+        # Specify that this URI should have a count of 2
+        req.add(AttrInfo.new(@type_a, @name_a, true, 2))
+        # Push both values onto the array
+        @msg.add_value(@type_a, @value_a)
+        @msg.add_value(@type_a, @value_a1)
         assert_equal(eargs, @msg.get_extension_args(req))
       end
 


### PR DESCRIPTION
Hi everyone,

It seems that this project is dead, but I'll try a pull request to see if anyone needs this feature.  The current AX implementation works fine with OpenID client libraries.  But it's a bit of a pain to parse the full specification manually.

This patch modifies the AX response to behave more like [Google's OpenID](https://developers.google.com/accounts/docs/OpenID?hl=ru#Samples).  I've Added support to manually define NS aliases in the AX FetchResponse.  Also added a short-hand response for attributes containing only one value.  

For example on the provider side:

``` ruby
axreq = OpenID::AX::FetchRequest.from_openid_request(oidreq)
axresp = OpenID::SparkAX::FetchResponse.new

uri="http://openid.net/schema/contact/internet/email"
axresp.set_values(uri, [someguy@example.com])
axresp.aliases.add_alias(uri, axreq.requested_attributes[ uri ].ns_alias)
oidresp.add_extension(axresp)
```

If the AX request from the client contained parameters like this:

> openid.ax.type.email=http://openid.net/schema/contact/internet/email
> openid.ax.required=email

Then the response would look like this:

> openid.ax.type.email=http://openid.net/schema/contact/internet/email
> openid.ax.value.email=someguy@example.com

Much easier for the client to parse than the default "extX.Y=value" style parameters.

Enjoy!  Please comment if you have questions, or patches to add.

--Cal
