### PR TITLE
Update starts/ends_with? to handle nil prefix

### DIFF
--- a/lib/openid/extras.rb
+++ b/lib/openid/extras.rb
@@ -1,10 +1,12 @@
 class String
   def starts_with?(other)
+    other = other.to_s
     head = self[0, other.length]
     head == other
   end
 
   def ends_with?(other)
+    other = other.to_s
     tail = self[-1 * other.length, other.length]
     tail == other
   end


### PR DESCRIPTION
This small change allows the `starts_with?` and `ends_with?` methods that are mixed in to `String` to take a nil argument. This matches the behavior of `start_with?` and `end_with?` in Ruby 1.8.7 and 1.9.3, which is particularly important when maintaining compatibility with other libraries (e.g. Rails) that alias `starts_with?` and `ends_with?` to `start_with?` and `end_with?`.
