### PR TITLE
fix licenses into gemspec

### DIFF
--- a/ruby-openid.gemspec
+++ b/ruby-openid.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/openid/ruby-openid'
   s.summary = 'A library for consuming and serving OpenID identities.'
   s.version = OpenID::VERSION
-  s.license = "Apache Software License"
+  s.licenses = ["Ruby", "Apache Software License 2.0"]
 
   # Files
   files = Dir.glob("{examples,lib,test}/**/*")


### PR DESCRIPTION
According to the LICENSE file, the licenses are "ruby" and "apache license
2.0". I am updating the gemspec accordingly.
