### PR TITLE
Stop overwriting String#starts_with? and String#ends_with? if defined

### DIFF
--- a/lib/openid/extras.rb
+++ b/lib/openid/extras.rb
@@ -3,11 +3,11 @@ class String
     other = other.to_s
     head = self[0, other.length]
     head == other
-  end
+  end unless ''.respond_to?(:starts_with?)
 
   def ends_with?(other)
     other = other.to_s
     tail = self[-1 * other.length, other.length]
     tail == other
-  end
+  end unless ''.respond_to?(:ends_with?)
 end


### PR DESCRIPTION
Let's not define ruby-openid version of `String#starts_with?` and `String#ends_with?` if they are already defined.
Since ActiveSupport simply aliases Ruby's `start_with?` and `end_with?` into these names 
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/string/starts_ends_with.rb, loading ruby-openid under a Rails app causes runtime warning `warning: method redefined; discarding old starts_with?`, and possibly cause some unexpected behavior change for the Rails app.
Of course I confirmed that test/test_extras.rb actually passes against the ActiveSupport version.
