### PR TITLE
Be aware when using Hash or Array as default value for unknown Hash keys

### DIFF
--- a/lib/openid/extensions/ax.rb
+++ b/lib/openid/extensions/ax.rb
@@ -275,8 +275,7 @@ module OpenID
       def initialize
         super()
         @mode = nil
-        @data = {}
-        @data.default = []
+        @data = Hash.new { |hash, key| hash[key] = [] }
       end
 
       # Add a single value for the given attribute type to the

--- a/lib/openid/store/memory.rb
+++ b/lib/openid/store/memory.rb
@@ -9,8 +9,7 @@ module OpenID
     class Memory < Interface
 
       def initialize
-        @associations = {}
-        @associations.default = {}
+        @associations = Hash.new { |hash, key| hash[key] = {} }
         @nonces = {}
       end
 


### PR DESCRIPTION
If you're using `Hash.new([])` or `Hash#default=` then it's the same object that is assigned to each unknown key, so you'll be adding to the same array when e.g. adding multiple AX attributes.

```
m = OpenID::AX::KeyValueMessage.new
m.add_value("a", "foo") # => ["foo"]
m.add_value("b", "bar") # => ["foo", "bar"]
m["a"] # => ["foo", "bar"]
```

By using a block to specify the default value, we get a new Array/Hash for each unknown key.

See also http://www.ruby-doc.org/core-2.0.0/Hash.html#new-method (same for all versions)
