### PR TITLE
Fixed missing XRDS HTTP header in sample provider

### DIFF
--- a/examples/rails_openid/app/controllers/server_controller.rb
+++ b/examples/rails_openid/app/controllers/server_controller.rb
@@ -207,8 +207,7 @@ EOS
 </xrds:XRDS>
 EOS
 
-    response.headers['content-type'] = 'application/xrds+xml'
-    render :text => yadis
+    render :text => yadis, :content_type => 'application/xrds+xml'
   end
 
   def add_sreg(oidreq, oidresp)


### PR DESCRIPTION
Apparently doing:

response.headers['content-type'] = 'application/xrds+xml'

doesn't set the Content-Type header (I don't know why). You can try it with curl -v.

This is the cause for issue #65.
