### PR TITLE
Allow expecting a parameter to be nil during return_to verification.

### DIFF
--- a/lib/openid/consumer/idres.rb
+++ b/lib/openid/consumer/idres.rb
@@ -160,7 +160,7 @@ module OpenID
         query = @message.to_post_args
         return_to_parsed_query.each_pair do |rt_key, rt_val|
           msg_val = query[rt_key]
-          if msg_val.nil?
+          if msg_val.nil? && !rt_val.nil?
             raise ProtocolError, "Message missing return_to argument '#{rt_key}'"
           elsif msg_val != rt_val
             raise ProtocolError, ("Parameter '#{rt_key}' value "\


### PR DESCRIPTION
There was a minor openid change on Google's side that caused all our applications using the ruby-openid gem to fail when authorizing users via Google openid.  After some debugging I determined the return_to parameter in the response from Google changed from:

``` ruby
{"user[email]"=>[""], "user[password]"=>[""], "user[identity_url]"=>["https://www.google.com/accounts/o8/id"]}
```

to:

``` ruby
{"user[email]"=>[], "user[password]"=>[], "user[identity_url]"=>["https://www.google.com/accounts/o8/id"]}
```

This causes the verify_return_to_args method to reject the response even though the rt_key (expected result) is nil.

``` ruby
if msg_val.nil?
  raise ProtocolError, "Message missing return_to argument '#{rt_key}'"
elsif msg_val != rt_val
  raise ProtocolError, ("Parameter '#{rt_key}' value "\
                                      "#{msg_val.inspect} does not match "\
                                      "return_to's value #{rt_val.inspect}")
end
```

Please accept my pull request that addresses this problem.  It doesn't reject the response if the rt_key (expected result) is also nil.
