### PR TITLE
Handle AX boolean value properly

### DIFF
--- a/lib/openid/util.rb
+++ b/lib/openid/util.rb
@@ -47,7 +47,14 @@ module OpenID
     def Util.urlencode(args)
       a = []
       args.each do |key, val|
-        val = '' unless val
+        if val.nil?
+          val = '' 
+        elsif !!val == val
+          #it's boolean let's convert it to string representation
+          # or else CGI::escape won't like it
+          val = val.to_s
+        end  
+
         a << (CGI::escape(key) + "=" + CGI::escape(val))
       end
       a.join("&")


### PR DESCRIPTION
If an AX attribute is set to boolean(true) value it results in 
undefined method `gsub' for true:TrueClass error. 

If it's set to false then its replaced by empty string resulting in 
to signature mismatch on the consumer, because the server still computes 
false AX value.

Fix is to set val to empty string if it's nil and if it's
boolean type then convert it to string.
