### PR TITLE
More safely build filenames

### DIFF
--- a/lib/openid/store/filesystem.rb
+++ b/lib/openid/store/filesystem.rb
@@ -230,15 +230,11 @@ module OpenID
       # create a safe filename from a url
       def filename_escape(s)
         s = '' if s.nil?
-        filename_chunks = []
-        s.split('').each do |c|
-          if @@FILENAME_ALLOWED.index(c)
-            filename_chunks << c
-          else
-            filename_chunks << sprintf("_%02X", c.bytes.first)
-          end
-        end
-        filename_chunks.join("")
+        filename_chunks = s.each_char.flat_map {|c|
+          @@FILENAME_ALLOWED.include?(c) ? c : c.bytes.map {|b|
+            "_%02X" % b
+          }
+        }.join
       end
 
       def safe64(s)


### PR DESCRIPTION
This avoids an error I was getting while parsing
http://localhost:8095/foo

`invalid value for Integer(): ":"`
