### PR TITLE
Avoid checking ancestors for constant

### DIFF
--- a/lib/openid/cryptutil.rb
+++ b/lib/openid/cryptutil.rb
@@ -37,7 +37,7 @@ module OpenID
     end
 
     def CryptUtil.hmac_sha1(key, text)
-      if Digest.const_defined? :HMAC
+      if Digest.const_defined? :HMAC, false
         Digest::HMAC.new(key,Digest::SHA1).update(text).digest
       else
         return HMAC::SHA1.digest(key, text)
@@ -49,7 +49,7 @@ module OpenID
     end
 
     def CryptUtil.hmac_sha256(key, text)
-      if Digest.const_defined? :HMAC
+      if Digest.const_defined? :HMAC, false
         Digest::HMAC.new(key,Digest::SHA256).update(text).digest
       else
         return HMAC::SHA256.digest(key, text)


### PR DESCRIPTION
When checking if `Digest::HMAC` is defined, we should not check ancestors,
we're only interested if `HMAC` is defined on `Digest`.

This will fix an issue in Ruby 2.2 where `Digest::HMAC` has been removed, but the
current check will result in the `Digest` library trying to load `digest/hmac` in 
`Digest.const_missing` and thus causing an error.