### PR TITLE
Use HMAC from OpenSSL rather than Digest.

### DIFF
--- a/lib/openid/cryptutil.rb
+++ b/lib/openid/cryptutil.rb
@@ -37,7 +37,7 @@ module OpenID
     end
 
     def CryptUtil.hmac_sha1(key, text)
-      if OpenSSL.const_defined? :HMAC, false
+      if defined? OpenSSL
         OpenSSL::HMAC.digest(OpenSSL::Digest::SHA1.new, key, text)
       else
         return HMAC::SHA1.digest(key, text)
@@ -49,7 +49,7 @@ module OpenID
     end
 
     def CryptUtil.hmac_sha256(key, text)
-      if OpenSSL.const_defined? :HMAC, false
+      if defined? OpenSSL
         OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, key, text)
       else
         return HMAC::SHA256.digest(key, text)

--- a/lib/openid/cryptutil.rb
+++ b/lib/openid/cryptutil.rb
@@ -2,7 +2,7 @@ require "openid/util"
 require "digest/sha1"
 require "digest/sha2"
 begin
-  require "digest/hmac"
+  require "openssl"
 rescue LoadError
   begin
     # Try loading the ruby-hmac files if they exist
@@ -37,8 +37,8 @@ module OpenID
     end
 
     def CryptUtil.hmac_sha1(key, text)
-      if Digest.const_defined? :HMAC, false
-        Digest::HMAC.new(key,Digest::SHA1).update(text).digest
+      if OpenSSL.const_defined? :HMAC, false
+        OpenSSL::HMAC.digest(OpenSSL::Digest::SHA1.new, key, text)
       else
         return HMAC::SHA1.digest(key, text)
       end
@@ -49,8 +49,8 @@ module OpenID
     end
 
     def CryptUtil.hmac_sha256(key, text)
-      if Digest.const_defined? :HMAC, false
-        Digest::HMAC.new(key,Digest::SHA256).update(text).digest
+      if OpenSSL.const_defined? :HMAC, false
+        OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, key, text)
       else
         return HMAC::SHA256.digest(key, text)
       end


### PR DESCRIPTION
The Digest::HMAC was an experimental implementation and has been removed
from the latest Ruby version (2.2).