### PR TITLE
Use RFC 2396 compatible URI parser for trustroot.

### DIFF
--- a/lib/openid/trustroot.rb
+++ b/lib/openid/trustroot.rb
@@ -178,7 +178,7 @@ module OpenID
         end
 
         begin
-          parsed = URI::parse(url)
+          parsed = URI::DEFAULT_PARSER.parse(url)
         rescue URI::InvalidURIError
           return nil
         end


### PR DESCRIPTION
From Ruby 2.2 the default `URI.parse` method uses a new RFC 3986
compatible parser, which will parse most of the “invalid” URLs in the
trustroot test.

The `URI::DEFAULT_PARSER` references the “old” RFC 2396 compatible 
URI parser in every version of Ruby I've tested.

Test script:
```sh
$ rvm 1.9.3,2.0.0,2.1,2.2,jruby,jruby-head,rbx do ruby -ruri -e "print %(#{RUBY_VERSION} : ); \
begin \
  URI::DEFAULT_PARSER.parse('http://*.schtuff.*/'); \
  p 'parsed'; \
rescue URI::InvalidURIError; \
  p 'invalid'; \
end"
```

Output:
```
1.9.3 : "invalid"
2.0.0 : "invalid"
2.1.5 : "invalid"
2.2.0 : "invalid"
1.9.3 : "invalid"
2.2.0 : "invalid"
2.1.0 : "invalid"
```

The same, using `URI.parse` instead, outputs:
```
1.9.3 : "invalid"
2.0.0 : "invalid"
2.1.5 : "invalid"
2.2.0 : "parsed"
1.9.3 : "invalid"
2.2.0 : "parsed"
2.1.0 : "invalid"
```