### PR TITLE
Build with new Ruby versions on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ rvm:
   - 2.0.0
   - "2.1"
   - "2.2"
+  - "2.3"
+  - "2.4"
   - ruby-head
-  - jruby-head
+  - jruby
   - jruby-19mode
   - rbx


### PR DESCRIPTION
Add 2.3 & 2.4
Use default newest jruby release (not head)