### PR TITLE
Rescue from Yadis::XRI::XRIHTTPError on discovery

### DIFF
--- a/lib/openid/consumer/discovery.rb
+++ b/lib/openid/consumer/discovery.rb
@@ -450,7 +450,7 @@ module OpenID
       services.each { |service_element|
         endpoints += flt.get_service_endpoints(iname, service_element)
       }
-    rescue Yadis::XRDSError => why
+    rescue Yadis::XRDSError, Yadis::XRI::XRIHTTPError => why
       Util.log('xrds error on ' + iname + ': ' + why.to_s)
     end
 


### PR DESCRIPTION
The error is explicitly thrown on any fetch errors by `Yadis::XRI::ProxyResolve#query` (including for bad URIs, network issues, invalid responses, ...) Since this error is not rescued anywhere today, it bubbles up beyond `OpenID::Consumer.begin` when called with e.g. an invalid URL like `"(this is not a URL)"` (including the parenthesis).

I'm not sure how to properly test this with the different mock-fetchers. For someone more accustomed with the tests, this might be easier :)