### PR TITLE
Ensure we always have an up-to-date bundler available on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ rvm:
   - jruby-head
   - jruby-19mode
   - rbx
+
+before_install:
+  - "gem install bundler"


### PR DESCRIPTION
This commit should fix the `jruby-head` build on Travis.

