### PR TITLE
read TIMEOUT from env first

### DIFF
--- a/lib/openid/fetchers.rb
+++ b/lib/openid/fetchers.rb
@@ -117,7 +117,7 @@ module OpenID
     USER_AGENT = "ruby-openid/#{OpenID::VERSION} (#{RUBY_PLATFORM})"
 
     REDIRECT_LIMIT = 5
-    TIMEOUT = 60
+    TIMEOUT = ENV['RUBY_OPENID_FETCHER_TIMEOUT'] || 60
 
     attr_accessor :ca_file
     attr_accessor :timeout


### PR DESCRIPTION
chineses government block specific http request, and the default TIMEOUT is 60 seconds
my rails app use unicorn, block a process 60s is unacceptable.

for now , I use some magic
```
OpenID::StandardFetcher.send :remove_const, 'TIMEOUT'
OpenID::StandardFetcher.const_set('TIMEOUT', 5)
```

it will be awesome if we read timeout from a environment variable ```RUBY_OPENID_FETCHER_TIMEOUT```first, same way as we manage ```http_proxy```