### PR TITLE
Add lib/ruby-openid.rb for Bundler.require

### DIFF
--- a/lib/ruby-openid.rb
+++ b/lib/ruby-openid.rb
@@ -1,0 +1,1 @@
+require 'openid'


### PR DESCRIPTION
To remove extra :require option like this:

```rb
gem "ruby-openid", require: "openid"
```

For example, we can test `Bundler.require`'s behavior by the following code:

```
$ ruby -r bundler -e "Bundler.require; puts defined?(OpenID::Consumer)"
constant
```

This change may be related to https://github.com/openid/ruby-openid/issues/48.