### PR TITLE
Add Ruby 2.6 and better Bundler support on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - "2.3"
   - "2.4"
   - "2.5"
+  - "2.6"
   - ruby-head
   - jruby
   - jruby-head
@@ -17,7 +18,7 @@ rvm:
   - rubinius-3
 
 before_install:
-  - "gem install bundler"
+  - "gem install bundler || gem install bundler --version '< 2'"
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Fall back to a pre-2 version of Bundler on older versions of Ruby, since v2.0 requires Ruby 2.3+