### PR TITLE
Drop deprecated option from gemspec

### DIFF
--- a/ruby-openid.gemspec
+++ b/ruby-openid.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # RDoc
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.md', 'INSTALL.md', 'LICENSE', 'UPGRADE.md']
   s.rdoc_options << '--main' << 'README.md'
 


### PR DESCRIPTION
This PR removes a warning-generating line from the gemspec.

This is the warning:

`NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.`