### PR TITLE
Perform checks first

### DIFF
--- a/lib/openid/consumer/idres.rb
+++ b/lib/openid/consumer/idres.rb
@@ -71,9 +71,9 @@ module OpenID
       # verified information.
       def id_res
         check_for_fields
-        verify_return_to
         check_signature
         check_nonce
+        verify_return_to
         verify_discovery_results
       end
 


### PR DESCRIPTION
My take is that this method will raise `ProtocolError` in the very first place (which is a good thing!) unless the request is a valid `id_res` response. Once it has been verified, the methods `endpoint`, `message`, and `signed_fields` contain the verified information.  
Thereby making everything secure from any third party interference.

Closes #124