### PR TITLE
chore: remove rubinius 3 as it is gone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ rvm:
   - jruby
   - jruby-head
   - jruby-19mode
-  - rubinius-3
 
 before_install:
   - "gem install bundler || gem install bundler --version '< 2'"


### PR DESCRIPTION
rubinius 3 can't be installed anymore. Remove so the pipelines are green again. 

```
rvm use rubinius-3 --install --binary --fuzzy
curl: (22) The requested URL returned error: 404 Not Found
Required rubinius-3 is not installed - installing.
curl: (22) The requested URL returned error: 404 Not Found
```
https://travis-ci.org/github/openid/ruby-openid/jobs/731856255

Sadly it can't be replaced with rubinius-5, as it's also unavailable for rvm (as it seems) (#132). 