### PR TITLE
chore: replace rubinius-3 with rubinius-5, as version 3 is not instal…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
   - jruby
   - jruby-head
   - jruby-19mode
-  - rubinius-3
+  - rubinius-5
 
 before_install:
   - "gem install bundler || gem install bundler --version '< 2'"


### PR DESCRIPTION
Instead of just removing the rubinius test run, replace it with a newer version. let's see if this runs successfully.