### PR TITLE
server: fix param length check for decode

### DIFF
--- a/lib/openid/server.rb
+++ b/lib/openid/server.rb
@@ -1240,7 +1240,7 @@ module OpenID
       # Raises ProtocolError when the query does not seem to be a valid
       # OpenID request.
       def decode(query)
-        if query.nil? or query.length == 0
+        if query.nil? or query.empty?
           return nil
         end
 


### PR DESCRIPTION
in the redmine plugin buri17/redmine_openid_provider, the following call:
app/controllers/open_id_provider_controller.rb:28
open_id_request = server.decode_request(params)

causes the following exception:
NoMethodError (undefined method `length' for #<ActionController::Parameters:0x00007f3a14e70608>)

params is a ActionController::Parameters.
in rails 4.x ActionController::Parameters was a Hash and had the length method.
in rails 5.x ActionController::Parameters is an object and does not have the
length method.
instead the empty? method can be used.

this fix replaces "params.length == 0" with the equivalent "params.empty?"